### PR TITLE
fix [cards] : colors & API

### DIFF
--- a/halo/src/commonMain/kotlin/org/bizilabs/halo/components/Accordions.kt
+++ b/halo/src/commonMain/kotlin/org/bizilabs/halo/components/Accordions.kt
@@ -19,8 +19,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import org.bizilabs.halo.components.cards.HaloCard
-import org.bizilabs.halo.components.cards.HaloOutlineCard
+import org.bizilabs.halo.components.cards.HaloFilledCard
+import org.bizilabs.halo.components.cards.HaloOutlinedCard
 
 /**
  * @param header items that will appear at the top
@@ -81,7 +81,7 @@ fun HaloFilledAccordion(
     onClick: () -> Unit = { },
     content: @Composable () -> Unit,
 ) {
-    HaloCard(modifier = modifier) {
+    HaloFilledCard(modifier = modifier) {
         AccordionBase(
             collapsed = collapsed,
             header = { HaloAccordionHeader(collapsed = collapsed, modifier = Modifier, header = header) },
@@ -100,7 +100,7 @@ fun HaloOutlinedAccordion(
     onClick: () -> Unit = { },
     content: @Composable () -> Unit,
 ) {
-    HaloOutlineCard(modifier = modifier) {
+    HaloOutlinedCard(modifier = modifier) {
         AccordionBase(
             collapsed = collapsed,
             header = {

--- a/halo/src/commonMain/kotlin/org/bizilabs/halo/components/avatars/BaseAvatar.kt
+++ b/halo/src/commonMain/kotlin/org/bizilabs/halo/components/avatars/BaseAvatar.kt
@@ -18,8 +18,8 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.SubcomposeAsyncImage
 import org.bizilabs.halo.HaloTheme
 import org.bizilabs.halo.base.HaloColor
-import org.bizilabs.halo.components.cards.HaloCard
-import org.bizilabs.halo.components.cards.HaloOutlineCard
+import org.bizilabs.halo.components.cards.HaloFilledCard
+import org.bizilabs.halo.components.cards.HaloOutlinedCard
 import org.bizilabs.halo.state.HaloBorder
 
 /**
@@ -163,7 +163,7 @@ private fun AvatarOutlineCard(
     shape: Shape = HaloTheme.shapes.medium,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    HaloOutlineCard(
+    HaloOutlinedCard(
         modifier = modifier,
         border = border,
         colors = colors,
@@ -192,7 +192,7 @@ private fun AvatarCard(
     shape: Shape = HaloTheme.shapes.medium,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    HaloCard(
+    HaloFilledCard(
         modifier = modifier,
         colors = colors,
         onClick = onClick,

--- a/halo/src/commonMain/kotlin/org/bizilabs/halo/components/cards/Cards.kt
+++ b/halo/src/commonMain/kotlin/org/bizilabs/halo/components/cards/Cards.kt
@@ -21,39 +21,53 @@ internal fun CardBase(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     onClick: (() -> Unit)? = null,
-    shape: Shape = CardDefaults.shape,
+    shape: Shape = HaloTheme.shapes.medium,
     colors: CardColors = CardDefaults.cardColors(),
     elevation: CardElevation = CardDefaults.cardElevation(),
     border: BorderStroke? = null,
     interactionSource: MutableInteractionSource? = null,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    Card(
-        onClick = onClick ?: {},
-        enabled = enabled,
-        modifier = modifier,
-        shape = shape,
-        colors = colors,
-        elevation = elevation,
-        border = border,
-        interactionSource = interactionSource,
-        content = content,
-    )
+    when (onClick != null) {
+        true ->
+            Card(
+                onClick = onClick,
+                enabled = enabled,
+                modifier = modifier,
+                shape = shape,
+                colors = colors,
+                elevation = elevation,
+                border = border,
+                interactionSource = interactionSource,
+                content = content,
+            )
+
+        false ->
+            Card(
+                modifier = modifier,
+                shape = shape,
+                colors = colors,
+                elevation = elevation,
+                border = border,
+                content = content,
+            )
+    }
 }
 
 @Composable
-fun HaloCard(
+fun HaloFilledCard(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     onClick: (() -> Unit)? = null,
-    shape: Shape = CardDefaults.shape,
+    shape: Shape = HaloTheme.shapes.medium,
     colors: CardColors =
         CardDefaults.cardColors(
             contentColor = HaloTheme.colorScheme.content.strong,
             containerColor = HaloTheme.colorScheme.background.surface,
+            disabledContentColor = HaloTheme.colorScheme.disabled.content,
+            disabledContainerColor = HaloTheme.colorScheme.disabled.container,
         ),
     elevation: CardElevation = CardDefaults.cardElevation(),
-    border: BorderStroke? = null,
     interactionSource: MutableInteractionSource? = null,
     content: @Composable ColumnScope.() -> Unit,
 ) {
@@ -64,7 +78,7 @@ fun HaloCard(
         shape = shape,
         colors = colors,
         elevation = elevation,
-        border = border,
+        border = null,
         interactionSource = interactionSource,
         content = content,
     )
@@ -75,11 +89,13 @@ fun HaloSlotCard(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     onClick: (() -> Unit)? = null,
-    shape: Shape = CardDefaults.shape,
+    shape: Shape = HaloTheme.shapes.medium,
     colors: CardColors =
         CardDefaults.cardColors(
             contentColor = HaloTheme.colorScheme.content.strong,
             containerColor = HaloTheme.colorScheme.background.surface,
+            disabledContentColor = HaloTheme.colorScheme.disabled.content,
+            disabledContainerColor = HaloTheme.colorScheme.disabled.container,
         ),
     elevation: CardElevation = CardDefaults.cardElevation(),
     strokeWidth: Dp = 2.dp,

--- a/halo/src/commonMain/kotlin/org/bizilabs/halo/components/cards/OutlineCards.kt
+++ b/halo/src/commonMain/kotlin/org/bizilabs/halo/components/cards/OutlineCards.kt
@@ -19,50 +19,65 @@ internal fun OutlineCardBase(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     onClick: (() -> Unit)? = null,
-    shape: Shape = CardDefaults.shape,
-    colors: CardColors =
-        CardDefaults.cardColors(
-            contentColor = HaloTheme.colorScheme.content.strong,
-            containerColor = HaloTheme.colorScheme.background.surface,
-        ),
+    shape: Shape = HaloTheme.shapes.medium,
+    colors: CardColors = CardDefaults.outlinedCardColors(),
     elevation: CardElevation = CardDefaults.cardElevation(),
     border: BorderStroke = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
     interactionSource: MutableInteractionSource? = null,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    OutlinedCard(
-        onClick = onClick ?: {},
-        enabled = enabled,
-        modifier = modifier,
-        shape = shape,
-        colors = colors,
-        elevation = elevation,
-        border = border,
-        interactionSource = interactionSource,
-        content = content,
-    )
+    when (onClick != null) {
+        true ->
+            OutlinedCard(
+                onClick = onClick,
+                enabled = enabled,
+                modifier = modifier,
+                shape = shape,
+                colors = colors,
+                elevation = elevation,
+                border = border,
+                interactionSource = interactionSource,
+                content = content,
+            )
+
+        false ->
+            OutlinedCard(
+                modifier = modifier,
+                shape = shape,
+                colors = colors,
+                elevation = elevation,
+                border = border,
+                content = content,
+            )
+    }
 }
 
 @Composable
-fun HaloOutlineCard(
+fun HaloOutlinedCard(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     onClick: (() -> Unit)? = null,
-    shape: Shape = CardDefaults.shape,
+    shape: Shape = HaloTheme.shapes.medium,
     colors: CardColors =
-        CardDefaults.cardColors(
+        CardDefaults.outlinedCardColors(
             contentColor = HaloTheme.colorScheme.content.strong,
             containerColor = HaloTheme.colorScheme.background.surface,
+            disabledContentColor = HaloTheme.colorScheme.disabled.content,
+            disabledContainerColor = HaloTheme.colorScheme.disabled.container,
         ),
     elevation: CardElevation = CardDefaults.cardElevation(),
-    border: BorderStroke = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+    border: BorderStroke =
+        BorderStroke(
+            HaloTheme.thickness.medium,
+            HaloTheme.colorScheme.content.weak,
+        ),
     interactionSource: MutableInteractionSource? = null,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     OutlineCardBase(
         modifier = modifier,
         enabled = enabled,
-        onClick = onClick ?: {},
+        onClick = onClick,
         shape = shape,
         colors = colors,
         elevation = elevation,

--- a/sample/desktop/src/desktopMain/kotlin/org/bizilabs/halo/desktop/screens/GalleryScreen.kt
+++ b/sample/desktop/src/desktopMain/kotlin/org/bizilabs/halo/desktop/screens/GalleryScreen.kt
@@ -30,8 +30,8 @@ import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.core.screen.Screen
 import org.bizilabs.halo.HaloTheme
 import org.bizilabs.halo.components.HaloText
-import org.bizilabs.halo.components.cards.HaloCard
-import org.bizilabs.halo.components.cards.HaloOutlineCard
+import org.bizilabs.halo.components.cards.HaloFilledCard
+import org.bizilabs.halo.components.cards.HaloOutlinedCard
 import org.bizilabs.halo.desktop.screens.accordion.AccordionSection
 import org.bizilabs.halo.desktop.screens.avatar.AvatarSection
 import org.bizilabs.halo.desktop.screens.badge.BadgeSection
@@ -191,7 +191,7 @@ fun GalleryItem(
     modifier: Modifier = Modifier,
     onClick: () -> Unit,
 ) {
-    HaloCard(
+    HaloFilledCard(
         modifier = modifier.height(150.dp),
         onClick = onClick,
     ) {
@@ -207,7 +207,7 @@ fun GalleryOutlineItem(
     title: String,
     modifier: Modifier = Modifier,
 ) {
-    HaloOutlineCard(modifier = modifier.height(150.dp)) {
+    HaloOutlinedCard(modifier = modifier.height(150.dp)) {
         Column(modifier = Modifier.padding(16.dp)) {
             Spacer(modifier = Modifier.weight(1f))
             HaloText(text = title)

--- a/sample/desktop/src/desktopMain/kotlin/org/bizilabs/halo/desktop/screens/card/CardSection.kt
+++ b/sample/desktop/src/desktopMain/kotlin/org/bizilabs/halo/desktop/screens/card/CardSection.kt
@@ -3,67 +3,177 @@ package org.bizilabs.halo.desktop.screens.card
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.Divider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import org.bizilabs.halo.HaloTheme
 import org.bizilabs.halo.components.HaloText
-import org.bizilabs.halo.components.cards.HaloCard
-import org.bizilabs.halo.components.cards.HaloOutlineCard
-import org.bizilabs.halo.components.cards.HaloSlotCard
+import org.bizilabs.halo.components.cards.HaloFilledCard
+import org.bizilabs.halo.components.cards.HaloOutlinedCard
 
 @Composable
 fun CardSection() {
     Column(modifier = Modifier.fillMaxWidth()) {
-        Column(modifier = Modifier.padding(bottom = 16.dp)) {
+        Column(modifier = Modifier.padding(16.dp)) {
             HaloText(
                 text = "A card is a contained unit of information related to a topic. ",
-                color = HaloTheme.colorScheme.content.stronger,
-                fontWeight = FontWeight.Light,
             )
         }
+        Divider(modifier = Modifier.fillMaxWidth(), color = HaloTheme.colorScheme.content.weak)
         LazyColumn(
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             item {
-                HaloCard(
-                    modifier = Modifier.padding(16.dp),
-                ) {
-                    Box(
-                        Modifier
-                            .padding(16.dp)
-                            .fillMaxWidth()
-                            .height(150.dp),
+                Column {
+                    HaloText(
+                        modifier = Modifier.padding(horizontal = 16.dp).padding(top = 16.dp),
+                        text = "Filled",
+                        style = HaloTheme.typography.subTitle,
                     )
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    ) {
+                        Column(
+                            modifier =
+                                Modifier
+                                    .weight(1f),
+                        ) {
+                            HaloText(
+                                modifier = Modifier.padding(vertical = 16.dp),
+                                text = "Normal",
+                                style = HaloTheme.typography.bodyMedium,
+                            )
+                            HaloFilledCard {
+                                Box(
+                                    Modifier
+                                        .padding(16.dp)
+                                        .fillMaxWidth()
+                                        .height(150.dp),
+                                )
+                            }
+                        }
+                        Column(
+                            modifier =
+                                Modifier
+                                    .weight(1f),
+                        ) {
+                            HaloText(
+                                modifier = Modifier.padding(vertical = 16.dp),
+                                text = "Clickable (Enabled)",
+                                style = HaloTheme.typography.bodyMedium,
+                            )
+                            HaloFilledCard(enabled = true, onClick = {}) {
+                                Box(
+                                    Modifier
+                                        .padding(16.dp)
+                                        .fillMaxWidth()
+                                        .height(150.dp),
+                                )
+                            }
+                        }
+                        Column(
+                            modifier =
+                                Modifier
+                                    .weight(1f),
+                        ) {
+                            HaloText(
+                                modifier = Modifier.padding(vertical = 16.dp),
+                                text = "Clickable (Disabled)",
+                                style = HaloTheme.typography.bodyMedium,
+                            )
+                            HaloFilledCard(enabled = false, onClick = {}) {
+                                Box(
+                                    Modifier
+                                        .padding(16.dp)
+                                        .fillMaxWidth()
+                                        .height(150.dp),
+                                )
+                            }
+                        }
+                    }
                 }
             }
             item {
-                HaloOutlineCard(
-                    modifier = Modifier.padding(16.dp),
-                ) {
-                    Box(
-                        Modifier
-                            .padding(16.dp)
-                            .fillMaxWidth()
-                            .height(150.dp),
+                Column {
+                    HaloText(
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        text = "Outlined",
+                        style = HaloTheme.typography.subTitle,
                     )
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    ) {
+                        Column(
+                            modifier =
+                                Modifier
+                                    .weight(1f),
+                        ) {
+                            HaloText(
+                                modifier = Modifier.padding(vertical = 16.dp),
+                                text = "Normal",
+                                style = HaloTheme.typography.bodyMedium,
+                            )
+                            HaloOutlinedCard {
+                                Box(
+                                    Modifier
+                                        .padding(16.dp)
+                                        .fillMaxWidth()
+                                        .height(150.dp),
+                                )
+                            }
+                        }
+                        Column(
+                            modifier =
+                                Modifier
+                                    .weight(1f),
+                        ) {
+                            HaloText(
+                                modifier = Modifier.padding(vertical = 16.dp),
+                                text = "Clickable (Enabled)",
+                                style = HaloTheme.typography.bodyMedium,
+                            )
+                            HaloOutlinedCard(enabled = true, onClick = {}) {
+                                Box(
+                                    Modifier
+                                        .padding(16.dp)
+                                        .fillMaxWidth()
+                                        .height(150.dp),
+                                )
+                            }
+                        }
+                        Column(
+                            modifier =
+                                Modifier
+                                    .weight(1f),
+                        ) {
+                            HaloText(
+                                modifier = Modifier.padding(vertical = 16.dp),
+                                text = "Clickable (Disabled)",
+                                style = HaloTheme.typography.bodyMedium,
+                            )
+                            HaloOutlinedCard(enabled = false, onClick = {}) {
+                                Box(
+                                    Modifier
+                                        .padding(16.dp)
+                                        .fillMaxWidth()
+                                        .height(150.dp),
+                                )
+                            }
+                        }
+                    }
                 }
             }
             item {
-                HaloSlotCard(
-                    modifier = Modifier.padding(16.dp),
-                ) {
-                    Box(
-                        Modifier
-                            .fillMaxWidth()
-                            .height(150.dp),
-                    )
-                }
+                Spacer(modifier = Modifier.padding(24.dp))
             }
         }
     }


### PR DESCRIPTION
## Description
> information of what was being worked on (__if necessary__)

fixes default card colors and API

## Notes
> additional information of what was being worked on like testing or something that changed (__if necessary__)

We should fix disabled color in light and dark mode respectively

## Issues
> issue number of what was being worked on (__if necessary__)

None

## Screenshot
> an image of what was being worked on (__if necessary__)

| Light | Dark |
|:---:|:---:|
|<img width="829" height="691" alt="Screenshot 2025-07-27 at 9 46 32 PM" src="https://github.com/user-attachments/assets/8aaf1322-93b5-4e16-be20-a529c31c8493" />|<img width="829" height="691" alt="Screenshot 2025-07-27 at 9 47 12 PM" src="https://github.com/user-attachments/assets/c9ebe536-c8b6-445e-bb2e-92b290390ace" />|

## Reviewers
> who's going to review the PR

@janewaitara @ericwafula 

[//]: # (remove your name above if you're the one who's created the PR)
