### PR TITLE
fix : charts crashing on null min and max values

### DIFF
--- a/charts/src/commonMain/kotlin/org/bizilabs/halo/charts/ui/HaloLineChart.kt
+++ b/charts/src/commonMain/kotlin/org/bizilabs/halo/charts/ui/HaloLineChart.kt
@@ -92,8 +92,16 @@ fun HaloLineChart(
     val minX = remember(allPoints) { allPoints.minOf { it.x } }
     val maxX = remember(allPoints) { allPoints.maxOf { it.x } }
 
-    val minY = remember(allPoints) { allPoints.mapNotNull { it.y }.minOf { it } }
-    val maxY = remember(allPoints) { allPoints.mapNotNull { it.y }.maxOf { it } }
+    val minY =
+        remember(allPoints) {
+            val values = allPoints.mapNotNull { it.y }
+            if (values.isEmpty()) 0f else values.minOf { it }
+        }
+    val maxY =
+        remember(allPoints) {
+            val values = allPoints.mapNotNull { it.y }
+            if (values.isEmpty()) 0f else values.maxOf { it }
+        }
 
     // Calculate Y-axis labels(In whole numbers) and the required padding.
     val yAxisLabels =


### PR DESCRIPTION
## Description
> information of what was being worked on (__if necessary__)

line chart crashes when looking for minimum and maximum values

## Notes
> additional information of what was being worked on like testing or something that changed (__if necessary__)

None

## Issues
> issue number of what was being worked on (__if necessary__)

None

## Screenshot
> an image of what was being worked on (__if necessary__)

None

## Reviewers
> who's going to review the PR

@janewaitara @ericwafula 

[//]: # (remove your name above if you're the one who's created the PR)
